### PR TITLE
Improve dojotoolkit

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+=== 1.1.1 / 07.07.2016
+
+* Improve dojotoolkit.rb
+
 === 1.1.0 / 06.07.2016
 
 * Rename djConfig to dojoConfig

--- a/lib/htmlgrid/version.rb
+++ b/lib/htmlgrid/version.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
 module HtmlGrid
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
Hi @zdavatz @ngiger 

This change has some improvements of dojotoolkit :battery: :battery: 

* removes old dojo syntax, completely
* makes it work with 1.7 (also >= 1.8)
* fixes html attributes to be passed to dojo widget.

And then, (finally) htmlgrid works only with dojo >= 1.7.0.

I've changed following points: :point_down: 

* Rename `dojo_parse_widgets` to `dojo_parse_on_load`
* Change `data-dojo-type` separator as `.` (`/` works only >= 1.8)
* Fix duplicated string closure in href
* Fix indent by tab