### PR TITLE
Fix session assignment issue

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+=== 1.1.3 / 15.08.2016
+
+* Add session variable fallback assignment
+
 === 1.1.2 / 10.08.2016
 
 * Fix warnings by syntax or coding style

--- a/lib/htmlgrid/composite.rb
+++ b/lib/htmlgrid/composite.rb
@@ -51,6 +51,21 @@ module HtmlGrid
 		CSS_ID = nil
 		DEFAULT_CLASS = Value
 		LOOKANDFEEL_MAP = {}
+
+    def self.component(klass, key, name=nil)
+      methname = klass.to_s.downcase.gsub('::', '_') << '_' << key.to_s
+      define_method(methname) { |*args|
+        model, session = args
+        args = [model.send(key), session || @session, self]
+        if(name)
+          args.unshift(name)
+          lookandfeel_map.store(methname.to_sym, name.to_sym)
+        end
+        klass.new(*args)
+      }
+      methname.to_sym
+    end
+
 		def init
 			super
 			setup_grid()
@@ -101,19 +116,6 @@ module HtmlGrid
 		end
 		def symbol_map
 			@symbol_map ||= self::class::SYMBOL_MAP.dup
-		end
-		def AbstractComposite.component(klass, key, name=nil)
-			methname = klass.to_s.downcase.gsub('::', '_') << '_' << key.to_s
-			define_method(methname) { |*args|
-				model, session = args
-				args = [model.send(key), session, self]
-				if(name)
-					args.unshift(name)
-					lookandfeel_map.store(methname.to_sym, name.to_sym)
-				end
-				klass.new(*args)
-			}
-			methname.to_sym
 		end
 	end
 	class TagComposite < AbstractComposite

--- a/lib/htmlgrid/version.rb
+++ b/lib/htmlgrid/version.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
 module HtmlGrid
-  VERSION = '1.1.2'
+  VERSION = '1.1.3'
 end

--- a/test/test_composite.rb
+++ b/test/test_composite.rb
@@ -88,6 +88,9 @@ module CompositeTest
     public :labels?
   end
   class StubCompositeModel
+    def qux
+      'qux'
+    end
   end
   class StubCompositeLookandfeel
     def event_url(one)
@@ -109,6 +112,9 @@ module CompositeTest
     def error(key)
     end
   end
+
+  class StubCompositeSession2 < StubCompositeSession; end
+
   class StubCompositeForm < HtmlGrid::Form
     COMPONENTS = {
       [0, 0] => StubComposite
@@ -141,6 +147,23 @@ module CompositeTest
       @composite = StubComposite.new(
         StubCompositeModel.new, StubCompositeSession.new)
     end
+
+    def test_component_session_fallback_assignment_without_session_argment
+      StubComposite.component(StubComposite, :qux)
+      model    = StubCompositeModel.new
+      session1 = StubCompositeSession.new
+      composite = StubComposite.new(model, session1)
+      # via instance variable (without argument)
+      composite = composite.compositetest_stubcomposite_qux(model)
+      assert_kind_of(StubCompositeSession, composite.session)
+      assert_equal(session1, composite.session)
+      # via argument
+      session2 = StubCompositeSession2.new
+      composite = composite.compositetest_stubcomposite_qux(model, session2)
+      assert_kind_of(StubCompositeSession2, composite.session)
+      assert_equal(session2, composite.session)
+    end
+
     def test_create_method
       foo = nil
       foo = @composite.create(:foo, @composite.model)


### PR DESCRIPTION
@zdavatz @ngiger 

I've added `@session` variable fallback assignment at `Component`.
This enables following way to create component instance at view.

```ruby
COMPONENTS = {
  [0, 0] => :foo,
  [0, 1] => component(ModelOrOtherComposite, :method) #=> this
}
```

This way is used well in davaz.com. See also [log](http://dev.ywesee.com/Yasu/20160815-migrate-davaz-com#fix-missing-session-argment-issue) about this issue.

And some test cases fail  by other reasons which are unrelated to this.
I will fix also these failures as next :)
