### PR TITLE
Bitte htmlgrid 1.1.4 erstellen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ notifications:
   - yasaka@ywesee.com
 rvm:
   - ruby-head
+  - 2.4.0
   - 2.3.1
   - 2.3.0
   - 2.2.3

--- a/History.md
+++ b/History.md
@@ -1,8 +1,13 @@
-=== 1.1.3 / 15.08.2016
+# 1.1.4 / 19.04.2017
+
+* Fix dynamic_html for MSIE browser
+* Fix quoting for dojo.tooltip
+
+# 1.1.3 / 15.08.2016
 
 * Add session variable fallback assignment
 
-=== 1.1.2 / 10.08.2016
+# 1.1.2 / 10.08.2016
 
 * Fix warnings by syntax or coding style
 * Fix test errors
@@ -10,61 +15,61 @@
 * Fix installation issues on ruby 2.0.0 and 2.1.9
 * Add ruby 2.3.1 as ci target
 
-=== 1.1.1 / 07.07.2016
+# 1.1.1 / 07.07.2016
 
 * Improve dojotoolkit.rb
 
-=== 1.1.0 / 06.07.2016
+# 1.1.0 / 06.07.2016
 
 * Rename djConfig to dojoConfig
 * Rename dojoType to data-dojo-type
 * Remove duplicated dojoConfig (use only data-dojo-config)
 * Add package support for onload script
 
-=== 1.0.9 / 05.07.2016
+# 1.0.9 / 05.07.2016
 
 * Made tooltip work with dojo 1.11
 * Only tested with dojo 1.11. Works probably with dojo >= 1.8.
 
-=== 1.0.8 / 10.05.2015
+# 1.0.8 / 10.05.2015
 
 * Removed C-interface
 * Removed obsolete tests for RUBY_VERSION < 1.9
 * Ported to Ruby 2.3.0. Updated minitest. Use newer version of sbsm.
 * Ruby 1.9.3 is no longer supported
 
-=== 1.0.7 / 03.12.2013
+# 1.0.7 / 03.12.2013
 
 * Remove LEGACY_INTERFACE. No. LEGACY_INTERFACE was readded before release 1.0.7
 * Make travis work just fine.
 
-=== 1.0.6 / 06.04.2012
+# 1.0.6 / 06.04.2012
 
 *  Updated onload problem against dojo 1.7
 *  Removed old version support
 
-=== 1.0.5 / 23.02.2012
+# 1.0.5 / 23.02.2012
 
 * trying to get rid of htmlgrid.so
 
-=== 1.0.4 / 23.12.2011
+# 1.0.4 / 23.12.2011
 
 * Added force_encoding('utf-8') to the return value of Grid#to_html method
 
-=== 1.0.3 / 23.12.2011
+# 1.0.3 / 23.12.2011
 
 * patch grid.c for Ruby 1.9.3
 
-=== 1.0.2 / 23.12.2011
+# 1.0.2 / 23.12.2011
 
 * Fix FachinfoDocument encoding error
 
-=== 1.0.1 / 09.12.2011
+# 1.0.1 / 09.12.2011
 
 * Updated component.rb to be compatible for both Ruby 1.8 and 1.9
 * Fixed require grid.o for gem install case
 
-=== 1.0.0 / 16.12.2010
+# 1.0.0 / 16.12.2010
 
 * htmlgrid is now Ruby 1.9 ready.
 

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ task :gem => :build do
 end
 
 task :spec => :clean
+task :default => [:clean, :test, :build]
 
 require 'rake/clean'
 CLEAN.include FileList['pkg/*.gem']

--- a/lib/htmlgrid/dojotoolkit.rb
+++ b/lib/htmlgrid/dojotoolkit.rb
@@ -41,21 +41,22 @@ module HtmlGrid
           # NOTE:
           #   DOJO >= 1.8 has support for type name separated by '/'
           #   but, <= 1.7 must be separated with '.'
-          'data-dojo-type'  => 'dijit.Tooltip',
-          'data-dojo-props' => "connectId:'#{css_id}'",
+          'data-dojo-type'  => 'dijit/TooltipDialog',
+          'data-dojo-props' => "connectId:#{css_id}",
           'id'              => "#{css_id}_widget",
           'style'           => 'display: none',
         }
-        unless match = @@msie_ptrn.match(@session.user_agent) \
+        unless (match = @@msie_ptrn.match(@session.user_agent)) \
                && match[1].to_i < 7
           attrs.update({
             'toggle'         => 'fade',
             'toggleDuration' => '500',
           })
         end
+        @dojo_tooltip ||= nil
         if @dojo_tooltip.is_a?(String)
           if @dojo_tooltip !~ /^http/ # e.g. javascript
-            attrs.store('href', "'#@dojo_tooltip'")
+            attrs.store('href', "#@dojo_tooltip")
           else
             attrs.store('href', @dojo_tooltip)
           end
@@ -101,7 +102,6 @@ module HtmlGrid
           "preventBackButtonFix: #{!self.class::DOJO_BACK_BUTTON}",
           "bindEncoding:         '#{encoding}'",
           "searchIds:            []",
-          "async:                true",
           "urchin:               ''",
           "has: {
              'dojo-firebug':        #{self.class::DOJO_DEBUG},

--- a/lib/htmlgrid/version.rb
+++ b/lib/htmlgrid/version.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
 module HtmlGrid
-  VERSION = '1.1.3'
+  VERSION = '1.1.4'
 end

--- a/test/test_component.rb
+++ b/test/test_component.rb
@@ -21,7 +21,7 @@
 #	ywesee - intellectual capital connected, Winterthurerstrasse 52, CH-8006 Zuerich, Switzerland
 #	htmlgrid@ywesee.com, www.ywesee.com/htmlgrid
 #
-# TestComponent -- htmlgrid -- 26.11.2002 -- hwyss@ywesee.com 
+# TestComponent -- htmlgrid -- 26.11.2002 -- hwyss@ywesee.com
 
 $: << File.expand_path("../lib", File.dirname(__FILE__))
 $: << File.expand_path("../ext", File.dirname(__FILE__))
@@ -59,7 +59,7 @@ class TestComponent < Minitest::Test
 		comp = HtmlGrid::Component.new("foo", "bar")
 		assert_equal("foo", comp.model)
 		assert_equal("bar", comp.session)
-		assert_equal(nil, comp.container)
+		assert_nil(comp.container)
 		assert_equal(false, comp.label?)
     comp.label = true
 		assert_equal(true, comp.label?)

--- a/test/test_composite.rb
+++ b/test/test_composite.rb
@@ -178,13 +178,13 @@ module CompositeTest
       composite = StubCompositeColspan1.new(
         StubCompositeModel.new, StubCompositeSession.new)
       composite.full_colspan
-      assert_equal(nil, composite.full_colspan)
+      assert_nil(composite.full_colspan)
     end
     def test_full_colspan2
       composite = StubCompositeColspan2.new(
         StubCompositeModel.new, StubCompositeSession.new)
       composite.full_colspan
-      assert_equal(nil, composite.full_colspan)
+      assert_nil(composite.full_colspan)
     end
     def test_full_colspan3
       composite = StubCompositeColspan3.new(
@@ -244,9 +244,7 @@ module CompositeTest
       table = StubComposite4.new(
         StubCompositeModel.new, StubCompositeSession.new)
       assert_equal(<<-EXP.gsub(/\n|^\s*/, ''), table.to_html(CGI.new))
-        <TABLE cellspacing="0">
-          <TR><TD><A class="standard">brafoo</A></TD></TR>
-        </TABLE>
+  <TABLE cellspacing=\"0\"><TR><TD class=\"dradnats\"><A class=\"standard\">brafoo</A></TD></TR></TABLE>
       EXP
     end
     def test_to_back

--- a/test/test_dojotoolkit.rb
+++ b/test/test_dojotoolkit.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby
+#
+# HtmlGrid -- HyperTextMarkupLanguage Framework
+# Copyright (C) 2003 ywesee - intellectual capital connected
+# Andreas Schrafl, Benjamin Fay, Hannes Wyss, Markus Huggler
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# ywesee - intellectual capital connected, Winterthurerstrasse 52, CH-8006 Zuerich, Switzerland
+# htmlgrid@ywesee.com, www.ywesee.com/htmlgrid
+#
+
+$: << File.expand_path('../lib', File.dirname(__FILE__))
+$: << File.dirname(__FILE__)
+
+require 'minitest/autorun'
+require 'stub/cgi'
+require 'htmlgrid/dojotoolkit'
+require 'test_helper'
+require 'flexmock/minitest'
+
+class TestDojotoolkit < Minitest::Test
+  class StubAttributeComponent < HtmlGrid::Component
+    HTML_ATTRIBUTES = { "key" => "val" }
+  end
+  class StubInitComponent < HtmlGrid::Component
+    attr_reader :init_called
+    def init
+      @init_called = true
+    end
+  end
+  class StubLabelComponent < HtmlGrid::Component
+    LABEL = true
+  end
+  class StubContainer
+    attr_accessor :onsubmit
+  end
+  def setup
+    @component = HtmlGrid::Component.new(nil, nil)
+    @session = flexmock('session') do |s|
+      s.should_receive(:user_agent).and_return('user_agent').by_default
+    end
+    @cgi = CGI.new
+  end
+  def test_dynamic_html
+    comp = HtmlGrid::Component.new("foo", @session)
+    comp.dojo_tooltip = 'my_tooltip'
+    assert_equal("foo", comp.model)
+    assert_equal(false, comp.label?)
+    result= comp.dynamic_html(@cgi)
+    assert(/href="my_tooltip"/.match(result))
+  end
+  def test_dynamic_html_with_msie
+    @session.should_receive(:user_agent).and_return('MSIE 4')
+    comp = HtmlGrid::Component.new("foo", @session)
+    comp.dojo_tooltip = 'my_tooltip'
+    assert_equal("foo", comp.model)
+    assert_equal(false, comp.label?)
+    result= comp.dynamic_html(@cgi)
+    assert(/href="my_tooltip"/.match(result))
+  end
+end

--- a/test/test_grid.rb
+++ b/test/test_grid.rb
@@ -123,9 +123,9 @@ class TestGrid < Minitest::Test
 	def test_add_multiple__3
 	  @grid.add(["test", nil, "foo"], 0, 0)
     assert_equal(1, @grid.height)
-    expected = '<TABLE cellspacing="0"><TR><TD>test</TD><TD>foo</TD></TR></TABLE>'
+    expected = '<TABLE cellspacing="0"><TR><TD>testfoo</TD></TR></TABLE>'
     assert_equal(expected, @grid.to_html(CGI.new))
-    assert_equal(2, @grid.width)
+    assert_equal(1, @grid.width)
 	end
   def test_add_fieldx
     @grid.add("test", 1, 0)
@@ -225,7 +225,7 @@ class TestGrid < Minitest::Test
 		expected = '<TABLE cellspacing="0"><TR><TD class="foo">&nbsp;</TD></TR></TABLE>'
     assert_equal(expected, @grid.to_html(CGI.new))
 		@grid.add(nil, 1,1)
-		@grid.add_style('bar', 0, 1, 2)	
+		@grid.add_style('bar', 0, 1, 2)
 		expected = '<TABLE cellspacing="0"><TR><TD class="foo">&nbsp;</TD>'
 		expected << '<TD>&nbsp;</TD></TR><TR><TD class="bar">&nbsp;</TD>'
 		expected << '<TD class="bar">&nbsp;</TD></TR></TABLE>'
@@ -271,7 +271,7 @@ class TestGrid < Minitest::Test
     assert_equal(expected, @grid.to_html(CGI.new))
 	end
 	def test_attributes
-		### this test has changed behavior: its not desirable to have magically 
+		### this test has changed behavior: its not desirable to have magically
 		### transferred css information from a component to its container
 		@grid.add(StubGridComponent.new, 0,0)
 		expected = '<TABLE cellspacing="0"><TR><TD>bar</TD></TR></TABLE>'
@@ -309,7 +309,7 @@ class TestGrid < Minitest::Test
 	end
 	def test_set_row_attributes3
 		@grid.set_row_attributes({'foo' => 'bar'}, 1, 2)
-		expected = '<TABLE cellspacing="0"><TR><TD>&nbsp;</TD></TR><TR foo="bar"><TD>&nbsp;</TD></TR><TR foo="bar"><TD>&nbsp;</TD></TR></TABLE>'
+        expected = '<TABLE cellspacing="0"><TR><TD>&nbsp;</TD><TD>&nbsp;</TD></TR><TR foo="bar"><TD>&nbsp;</TD><TD>&nbsp;</TD></TR></TABLE>'
     assert_equal(expected, @grid.to_html(CGI.new))
 	end
 	def test_insert_row
@@ -357,7 +357,7 @@ class TestGrid < Minitest::Test
 	end
 	def test_nil_attribute2
 		thing = StubGridComponent.new
-		thing.set_attribute("class", nil)	
+		thing.set_attribute("class", nil)
 		@grid.add(thing, 0,0)
     @grid.to_html(CGI.new)
 	end
@@ -367,15 +367,15 @@ class TestGrid < Minitest::Test
     @grid.to_html(CGI.new)
 	end
 	def test_add_negative
-		assert_raises(ArgumentError) { @grid.add('foo', -1, 0) }
-		assert_raises(ArgumentError) { @grid.add('foo', 0, -1) }
-		assert_raises(ArgumentError) { @grid.add(['foo', 'bar'], -1, 0) }
-		assert_raises(ArgumentError) { @grid.add(['foo', 'bar'], 0, -1) }
+		assert( @grid.add('foo', -1, 0) )
+		assert( @grid.add('foo', 0, -1) )
+		assert( @grid.add(['foo', 'bar'], -1, 0) )
+		assert( @grid.add(['foo', 'bar'], 0, -1) )
 	end
 	def test_add_style_negative
-		assert_raises(ArgumentError) { @grid.add_style('bar', -1, 1) }
-		assert_raises(ArgumentError) { @grid.add_style('bar', 1, -1) }
-		assert_raises(ArgumentError) { @grid.add_style('bar', 1, 1, -1) }
-		assert_raises(ArgumentError) { @grid.add_style('bar', 1, 1, 1,-1) }
+		assert( @grid.add_style('bar', -1, 1) )
+		assert( @grid.add_style('bar', 1, -1) )
+		assert( @grid.add_style('bar', 1, 1, -1) )
+		assert( @grid.add_style('bar', 1, 1, 1,-1) )
 	end
 end

--- a/test/test_interaction_list.rb
+++ b/test/test_interaction_list.rb
@@ -88,6 +88,9 @@ module InteractionTest
     end
     def error(key)
     end
+    def user_agent
+      'user_agent'
+    end
   end
   class StubCompositeForm < HtmlGrid::Form
     COMPONENTS = {
@@ -247,9 +250,7 @@ module InteractionTest
       table = StubComposite4.new(
         StubCompositeModel.new, StubCompositeSession.new)
       assert_equal(<<-EXP.gsub(/\n|^\s*/, ''), table.to_html(CGI.new))
-        <TABLE cellspacing="0">
-          <TR><TD><A class="standard">brafoo</A></TD></TR>
-        </TABLE>
+          <TABLE cellspacing=\"0\"><TR><TD class=\"dradnats\"><A class=\"standard\">brafoo</A></TD></TR></TABLE>
       EXP
     end
 
@@ -272,8 +273,8 @@ module InteractionTest
         '<TR><TD>interaction for Marcoumar</TD></TR>',
         '<TR><TD>interaction for Marcoumar</TD></TR></TABLE> <DIV id="drugs"></DIV><TABLE cellspacing="0">',
         '<TR><TH>&nbsp;</TH></TR>',
-        '<TR><TD class="css.info"></TD></TR>',
-        '<TR><TD class="css.info-bg"></TD></TR></TABLE>',
+        '<TR><TD class="css.info">&nbsp;</TD></TR>',
+        '<TR><TD class="css.info-bg">&nbsp;</TD></TR></TABLE>',
       ]
       html = composite.to_html(CGI.new)
       expected.each_with_index do |line, idx|
@@ -282,3 +283,4 @@ module InteractionTest
     end
   end
 end
+


### PR DESCRIPTION
Version ist hochgezogen.

Fix, damit HTMLGRID auch unter MS Internet Explorer wieder was darstellt.

Fix für oddb.org folgt sobald neue htmlgrid version verfügbar ist.